### PR TITLE
Creates a simulator for focusing an element on firefox.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-preset-metal": "^4.0.0",
     "gulp": "^3.8.11",
     "gulp-metal": "^1.0.0",
+    "metal-useragent": "^2.1.1",
     "steel-bootstrap": "metal/steel-bootstrap#master"
   }
 }

--- a/test/Autocomplete.js
+++ b/test/Autocomplete.js
@@ -3,6 +3,7 @@
 import { async } from 'metal';
 import { Align } from 'metal-position';
 import Autocomplete from '../src/Autocomplete';
+import UA from 'metal-useragent';
 import dom from 'metal-dom';
 
 var component;
@@ -12,6 +13,14 @@ var filterData = function(query) {
 	return ['Alabama', 'Alaska'].filter(function(item) {
 		return item.toLowerCase().indexOf(query.toLowerCase()) === 0;
 	});
+};
+
+var simulateFocus = function(element) {
+	element.focus();
+
+	if (UA.isFirefox) {
+		dom.triggerEvent(element, 'focus');
+	}
 };
 
 describe('Autocomplete', function() {
@@ -134,7 +143,7 @@ describe('Autocomplete', function() {
 		dom.enterDocument(otherInput);
 
 		input.setAttribute('value', 'a');
-		input.focus();
+		simulateFocus(input);
 		async.nextTick(function() {
 			async.nextTick(function() {
 				async.nextTick(function() {
@@ -156,7 +165,7 @@ describe('Autocomplete', function() {
 		});
 
 		input.setAttribute('value', 'a');
-		input.focus();
+		simulateFocus(input);
 		async.nextTick(function() {
 			async.nextTick(function() {
 				assert.ok(component.visible);
@@ -175,7 +184,7 @@ describe('Autocomplete', function() {
 		});
 
 		input.value = 'Alabama';
-		dom.triggerEvent(input, 'focus');
+		simulateFocus(input);
 
 		async.nextTick(function() {
 			assert.ok(component.visible);


### PR DESCRIPTION
This is for testing only.

Firefox does not fire focus event by element.focus() method. So that, we need to call both, element.focus() and metal.dom.triggerEvent(). The focus() method will update the document.activeElement and we need to trigger the event calling metal.dom.triggerEvent().